### PR TITLE
Hide vote button when you can't vote yet, add yarn command, add image rounding

### DIFF
--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -35,4 +35,4 @@ jobs:
           service: pinata
           pinataKey: ${{ secrets.PINATA_KEY }}
           pinataSecret: ${{ secrets.PINATA_SECRET }}
-          pinataPinName: wax-govboard-mainnet@v0.1.7
+          pinataPinName: wax-govboard-mainnet@master

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,4 +35,4 @@ jobs:
           service: pinata
           pinataKey: ${{ secrets.PINATA_KEY }}
           pinataSecret: ${{ secrets.PINATA_SECRET }}
-          pinataPinName: wax-govboard-testnet@v0.1.7
+          pinataPinName: wax-govboard-testnet@master

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start:testnet": "env-cmd -f .env.testnet react-scripts start",
+    "start:prod": "env-cmd -f .env.production react-scripts start",
     "build": "react-scripts build",
     "build:testnet": "env-cmd -f .env.testnet react-scripts build",
     "build:prod": "env-cmd -f .env.production react-scripts build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govboard",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "proxy": "http://localhost:3000",
   "dependencies": {

--- a/src/components/Vote.js
+++ b/src/components/Vote.js
@@ -107,8 +107,7 @@ class Vote extends React.Component {
                         candidates: newCandidates,
                     });
                 }
-
-                this.setState({
+               this.setState({
                     ballot: activeBallot.ballot,
                     title: activeBallot.title,
                     description: activeBallot.description,
@@ -488,7 +487,7 @@ class Vote extends React.Component {
                                         {this.state.candidates
                                             .slice(this.state.prevPage, this.state.nextPage)
                                             .map((candidate, key) => (
-                                                <CandidateGrid data={candidate} ballot={this.props.ballot} activeUser={this.props.activeUser} />
+                                                <CandidateGrid data={candidate} ballot={this.props.ballot} activeUser={this.props.activeUser} electionState={this.props.electionState} />
                                             ))}
                                     </React.Fragment>
                                 ) : (

--- a/src/partials/candidate-grid-template.js
+++ b/src/partials/candidate-grid-template.js
@@ -39,6 +39,7 @@ class CandidateGrid extends React.Component {
                         gridRowStart: 1,
                         gridColumnEnd: 1,
                         gridRowEnd: 1,
+                        borderRadius: '1em'
                     },
                     '& .content': {
                         display: 'flex',
@@ -73,9 +74,25 @@ class CandidateGrid extends React.Component {
                     <GLOBAL_STYLE.P className="owner">{this.props.data.owner}</GLOBAL_STYLE.P>
                     <GLOBAL_STYLE.H6 className="voteCount">{this.props.data.value}S</GLOBAL_STYLE.H6>
                 </div>
-                <GLOBAL_STYLE.Button className="voteButton" onClick={this.VoteCandidate}>
-                    Vote for {this.props.data.name}
-                </GLOBAL_STYLE.Button>
+                {
+                    this.props.electionState === 4 // voting open
+                    ? (
+                        this.props.activeUser // has logged in
+                        ? (
+                    <React.Fragment>
+                        <GLOBAL_STYLE.Button className="voteButton" onClick={this.VoteCandidate}>
+                            Vote for {this.props.data.name}
+                        </GLOBAL_STYLE.Button>
+                    </React.Fragment>
+                        ) 
+                        : (// could add something like this: <span className="alert">Login to vote</span>
+                    <React.Fragment></React.Fragment>
+                        )
+                    ) 
+                    : (
+                <React.Fragment></React.Fragment>
+                    )
+                }
                 <GLOBAL_STYLE.CustomLink text className="candidateLink" to={'/candidates/' + this.props.data.owner}>
                     Learn more about {this.props.data.name}
                 </GLOBAL_STYLE.CustomLink>


### PR DESCRIPTION
There was no yarn command to load test/prod environments, so added those

The vote button was showing even when the vote wasn't open yet; passed through the election state that was available to hide the buttons when you can't vote yet.

Also added a 1em rounding to the profile pictures to make it fit the rest of the site better.